### PR TITLE
Feature/line breaking

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,6 +1,6 @@
 <div class="container">
-  <div style="background: #0000ff; padding: 10px;">
-    <p style="background: #00ffff;">Hello <span class="world">World<span class="hey">Hey</span><span style="background: #ccaa00ff;">Hey</span>Yahoo</span>aBcD</p>
+  <div style="background: #000000; padding: 10px;">
+    <p style="background: #00ffff;">Hello <span class="world">World<span class="hey">Hey To enable WebAssembly to be read and edited by humans, there is a textual representation of <span class="wasm">the wasm binary format</span>. This is an intermediate form designed to be exposed in text editors, browser developer tools, etc. This article explains how that text format works, in terms of the raw syntax, and how it is related to the underlying bytecode it represents.</span><span style="background: #ccaa00ff;">TEST</span></span>WEB</p>
     <p style="background: #ff00ff;"><span class="hey">Hey</span>, Browser</p>
   </div>
 </div>

--- a/example/stylesheet.css
+++ b/example/stylesheet.css
@@ -6,7 +6,7 @@ span {
   display: inline;
   padding: 3px;
   margin: 5px;
-  border-color: #b8860b;
+  border-color: #ff0f0f;
   border-left-width: 1px;
   border-top-width: 1px;
   border-right-width: 1px;
@@ -16,12 +16,16 @@ span {
 .container {
   font-size: 20px;
   padding: 10px;
-  background: #000000;
 }
 
 .world {
   background: #0f00f0;
   color: #ff00ff;
+}
+
+.wasm {
+  background: #000000;
+  color: #ffffff;
 }
 
 .hey {

--- a/specifications/inline.md
+++ b/specifications/inline.md
@@ -96,6 +96,38 @@ CSS3: https://drafts.csswg.org/css-inline-3/
 - `inline box`のユーザー定義の`width`は適用されない
 - `margin-right`と`margin-left`の値は`0`になる
 
+## Line Breaking
+
+- `forced line break` ... 明示的に行の分割が操作されている、または、blockの始まり、または終わりによって分割されること
+- `soft wrap break` ... コンテンツの折り返しによって行が分割された場合。例えば、測定しているbox内にコンテンツがfitしているために非強制的な行分割が行われている時。
+- inline-levelのコンテンツを複数の行に分割する作業は行分割(`line breaking`)と呼ばれる
+- 折り返しは、許可された分割ポイントでのみ行われる。これは[soft wrap opportunity](soft-wrap-opportunity)と呼ばれる。
+- 折り返しが、[white-space](https://www.w3.org/TR/css-text-3/#propdef-white-space)によって有効になっている場合、`soft wrap opportunity`が存在するなら、ここで行を折り返すことによって、コンテンツがオーバーフローする量を最小化しなければならない。
+- 句読点で行分割をすることをおすすめする
+- 優先順位を適用するために、`containing block`の`width`、文字の言語、`line-break`の値、さらに他の要因を使う
+- CSSは`line break opportunity`の優先順位を定義していない
+- もし`word-break: break-all;`、`line-break: anywhere;`が指定されているなら、単語分割の優先順位は期待されない(どこでも改行できる)
+- `out of flow`要素や`inline element`の境界では改行は起こらない
+- たとえ通常はそれらを抑制するための文字(`NO-BREAK SPACE`)に隣接していたとしても、webの互換性のために、画像などのreplaced要素やその他のatomic inlineの前後で`soft wrap opportunity`がある
+- 改行で消える文字によって作られる`soft wrap opportunity`の場合、その文字を直接含むボックスのプロパティは、それらの機会に改行を制御する(おそらく、overflowした段階で初めて改行が制御されるということ)
+- 二つの文字の間の境界によって定義される`soft wrap opportunity`の場合、最も近い共通の祖先の`white-space`が分割を制御する。(`white-space`を参考に改行の方法を決める)
+- `soft wrap opportunity`の前の最初と後の最後の文字のboxの場合、分割はboxのコンテンツの端とコンテンツの間というよりもむしろ、boxの前後(marginの端)ですぐに起こる
+- [ruby boxの定義](https://www.w3.org/TR/css-ruby-1/#line-breaks)
+
+
+### soft wrap opportunity
+
+- 多くのWriting Systemではハイフネーション(英単語の途中で改行になった時に`-`で一続きの単語であることを意味すること)がない場合、単語の境界で`soft wrap opportunity`が起こる
+- 多くのシステムでは、スペースや句読点をいくつかの単語を分割するために使う。そして、`soft wrap opportunity`はそれらの単語によって起こる
+- タイやクメール語ではスペースや句読点を単語の分割のために使わない(**これはサポートしない**)
+- いくつかの他のWriting Systemでは単語の境界ではなく、正書法の音節境界(?)をベースにしている
+- 中国語や日本語では、いくつかの音節が一つの書体文の単位に対応する傾向がある。従って、行分割の慣習は特定の文字の間を除いて、どこでも分割することができる
+- CSSでは`soft wrap opportunity`を区別するためのいくつかの方法を提供している
+  - `line-break` ... 行分割の制限の様々な厳格なレベルを選ぶことができる
+  - `word-break` ... 日本語や中国語のようなまとめられていて分割不可能な文を形成するために、CJK文字をnon-CJKのように扱う
+  - `hyphens` ... ハイフネーションが行を分割することを許可される
+  - `overflow-wrap` ... 溢れる可能性のある、分割不可能な文字を分割する
+
 ## Servo Code Reading
 
 path: `servo/components/line.rs`

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -215,6 +215,13 @@ impl<'a> LineBreaker<'a> {
                     _ => unreachable!(),
                 };
                 node.range = inline_start.range.clone();
+
+                // remove whitespace on line end.
+                // TODO: text should has only one whitespace.
+                if node.get_text().chars().last().unwrap().is_whitespace() {
+                    node.range.end -= 1;
+                }
+
                 let metrics = self
                     .pending_line
                     .metrics

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -1,9 +1,21 @@
 use super::font::Font;
-use super::{BoxType, Dimensions, LayoutBox, Rect, TextNode};
+use super::{BoxType, Dimensions, LayoutBox, Rect, TextNode, SplitInfo};
 use std::collections::VecDeque;
 use std::iter::Iterator;
 use std::mem;
 use std::ops::Range;
+
+#[derive(Clone)]
+struct LineState {
+    inline_start: Option<SplitInfo>,
+    inline_end: Option<SplitInfo>,
+}
+
+impl LineState {
+    fn new() -> LineState {
+        LineState { inline_start: None, inline_end: None }
+    }
+}
 
 #[derive(Clone)]
 struct Line {
@@ -12,6 +24,7 @@ struct Line {
     green_zone: Rect,
     metrics: LineMetrics,
     is_line_broken: bool,
+    line_state: LineState,
 }
 
 impl Line {
@@ -22,6 +35,7 @@ impl Line {
             green_zone: Default::default(),
             metrics: LineMetrics::new(),
             is_line_broken: false,
+            line_state: LineState::new()
         }
     }
 }
@@ -34,9 +48,6 @@ struct LineBreaker<'a> {
     // Largest width in each lines
     max_width: f32,
     cur_height: f32,
-    // This value is express index of text range
-    // If this value has index, line is broken
-    last_known_line_breaking_opportunity: Option<usize>,
 }
 
 impl<'a> LineBreaker<'a> {
@@ -48,7 +59,6 @@ impl<'a> LineBreaker<'a> {
             pending_line: Line::new(Default::default()),
             max_width: 0.0,
             cur_height: 0.0,
-            last_known_line_breaking_opportunity: None,
         }
     }
 
@@ -72,6 +82,10 @@ impl<'a> LineBreaker<'a> {
     {
         while let Some(layout_box) = &mut self.next_layout_box(iter_old_boxes) {
             self.layout(root, layout_box);
+
+            self.pending_line.range.end += 1;
+            self.new_boxes.push(layout_box.clone());
+
             if self.pending_line.is_line_broken {
                 self.flush_current_line();
             }
@@ -95,8 +109,6 @@ impl<'a> LineBreaker<'a> {
             }
         }
 
-        self.pending_line.range.end += 1;
-
         match &layout_box.box_type {
             BoxType::InlineNode(_) => self.layout_inline(root, layout_box),
             BoxType::TextNode(_) => self.layout_text(layout_box),
@@ -106,15 +118,22 @@ impl<'a> LineBreaker<'a> {
     }
 
     fn layout_inline(&mut self, root: &Dimensions, layout_box: &mut LayoutBox<'a>) {
-        layout_box.assign_horizontal_margin_box();
+        if !layout_box.is_splitted {
+            layout_box.assign_horizontal_margin_box();
+        }
         layout_box.assign_vertical_margin_box();
 
         {
             let d = layout_box.dimensions.borrow();
-            self.pending_line.bounds.content.width += d.margin_left_offset() + d.margin_right_offset();
+            self.pending_line.bounds.content.width += d.margin_left_offset();
         }
-        
+
         self.calculate_inline_descendant_position(root, layout_box);
+
+        {
+            let d = layout_box.dimensions.borrow();
+            self.pending_line.bounds.content.width += d.margin_right_offset();
+        }
     }
 
     fn calculate_inline_descendant_position(
@@ -126,65 +145,60 @@ impl<'a> LineBreaker<'a> {
         let containing_block = &layout_box.dimensions;
         let mut new_children = vec![];
         let mut broken_line_children = vec![];
+        let mut end_layout_box: LayoutBox<'a> = layout_box.clone();
 
-        let mut i = 0;
         for child in &mut layout_box.children {
-            self.layout(root, child);
-
-            if self.pending_line.is_line_broken && broken_line_children.len() != 0 {
+            if self.pending_line.is_line_broken {
                 broken_line_children.push(child.clone());
                 continue;
             }
 
+            self.layout(root, child);
+
+            // Child is text node in here
             if self.pending_line.is_line_broken {
                 if let Some(layout_box) = self.work_list.pop_front() {
-                    broken_line_children.push(layout_box);
-                } else {
-                    break;
-                };
+                    broken_line_children.push(layout_box.clone());
+                }
+
+                if self.pending_line.line_state.inline_start.is_some() {
+                    let mut d = containing_block.borrow_mut();
+                    d.margin.right = 0.;
+                    d.border.right = 0.;
+                    d.padding.right = 0.;
+                }
+
+                if self.pending_line.line_state.inline_end.is_some() {
+                    let mut end_d = end_layout_box.dimensions.borrow_mut();
+                    end_d.margin.left = 0.;
+                    end_d.border.left = 0.;
+                    end_d.padding.left = 0.;
+                    end_layout_box.is_splitted = true;
+                }
             }
 
             {
                 let mut d = child.dimensions.borrow_mut();
                 let margin_box = d.margin_horizontal_box();
-                if self.lines.len() != 0 {
-                    d.content.x += total_width;
-                    if i == 0 {
-                        total_width += margin_box.width - d.margin_left_offset();
-                    } else {
-                        total_width += margin_box.width;
-                    }
-                } else {
-                    d.content.x += total_width + containing_block.borrow().margin_left_offset();
-                    total_width += margin_box.width;
-                }
+                // calculate position in inline box
+                d.content.x = total_width;
+                total_width += margin_box.width;
             }
 
             new_children.push(child.clone());
-
-            // Remove descendant from new_boxes
-            self.pending_line.range.end -= 1;
-            self.new_boxes.pop();
-            i += 1;
         }
 
         if self.pending_line.is_line_broken && broken_line_children.len() != 0 {
-            let mut new_layout_box = layout_box.clone();
-            new_layout_box.children = broken_line_children;
-            self.work_list.push_front(new_layout_box);
+            end_layout_box.children = broken_line_children;
+            self.work_list.push_front(end_layout_box);
         }
 
-        if new_children.len() != 0 {
-            layout_box.children = new_children;
-            {
-                let mut containing_block = containing_block.borrow_mut();
-                containing_block.content.width = total_width;
-                containing_block.content.height =
-                    Font::new_from_style(layout_box.get_style_node()).ascent;
-            }
-            self.new_boxes.push(layout_box.clone());
-        } else {
-            self.pending_line.range.end -= 1;
+        layout_box.children = new_children;
+        {
+            let mut containing_block = containing_block.borrow_mut();
+            containing_block.content.width = total_width;
+            containing_block.content.height =
+                Font::new_from_style(layout_box.get_style_node()).ascent;
         }
     }
 
@@ -200,21 +214,16 @@ impl<'a> LineBreaker<'a> {
             self.pending_line.green_zone.width - self.pending_line.bounds.content.width;
 
         if text_width >= remaining_width || self.pending_line.is_line_broken {
-            if self.pending_line.is_line_broken {
-                self.pending_line.range.end -= 1;
-                return;
-            }
-
             self.pending_line.is_line_broken = true;
 
             let (inline_start, inline_end) = node.calculate_split_position(node, remaining_width);
 
-            if let Some(inline_start) = inline_start {
+            if let Some(inline_start) = &inline_start {
                 let mut node = match &mut layout_box.box_type {
                     BoxType::TextNode(node) => node,
                     _ => unreachable!(),
                 };
-                node.range = inline_start.range;
+                node.range = inline_start.range.clone();
                 let metrics = self
                     .pending_line
                     .metrics
@@ -228,19 +237,21 @@ impl<'a> LineBreaker<'a> {
                     d.content.width = text_width;
                 }
                 self.pending_line.bounds.content.width += text_width;
-                self.new_boxes.push(layout_box.clone());
             }
 
-            if let Some(inline_end) = inline_end {
+            if let Some(inline_end) = &inline_end {
                 let mut new_layout_box = layout_box.clone();
                 let mut node = match &mut new_layout_box.box_type {
                     BoxType::TextNode(node) => node,
                     _ => unreachable!(),
                 };
-                node.range = inline_end.range;
+                node.range = inline_end.range.clone();
                 new_layout_box.dimensions.borrow_mut().content.y = 0.;
                 self.work_list.push_front(new_layout_box);
             }
+
+            self.pending_line.line_state.inline_start = inline_start;
+            self.pending_line.line_state.inline_end = inline_end;
         } else {
             let metrics = self
                 .pending_line
@@ -254,7 +265,6 @@ impl<'a> LineBreaker<'a> {
                 d.content.width = text_width;
             }
             self.pending_line.bounds.content.width += text_width;
-            self.new_boxes.push(layout_box.clone());
         }
     }
 
@@ -285,30 +295,6 @@ impl<'a> LineBreaker<'a> {
         self.lines.push(self.pending_line.clone());
         self.pending_line = Line::new(Default::default());
     }
-
-    fn reset_line_edge(&mut self) {
-        if self.lines.len() == 0 {
-            return;
-        }
-
-        let mut line_index = 0;
-        let last_line_index = self.lines.len() - 1;
-        for line in &self.lines {
-            let box_list = &mut self.new_boxes[line.range.clone()];
-            if box_list.len() == 0 {
-                break;
-            }
-            if line_index != 0 {
-                let item = &mut box_list[0];
-                item.reset_edge_left();
-            }
-            if line_index != last_line_index {
-                let item = &mut box_list[box_list.len() - 1];
-                item.reset_edge_right();
-            }
-            line_index += 1;
-        }
-    }
 }
 
 pub struct InlineBox<'a> {
@@ -333,13 +319,13 @@ impl<'a> InlineBox<'a> {
         let old_boxes = mem::replace(&mut self.boxes, Vec::new());
         let mut iter_old_boxes = old_boxes.into_iter();
         line_breaker.scan_for_line(&self.root, &mut iter_old_boxes);
-        line_breaker.reset_line_edge();
         self.assign_position(&mut line_breaker);
         self.boxes = line_breaker.new_boxes;
         self.width = line_breaker.max_width;
         self.height = line_breaker.cur_height;
     }
 
+    /// calculate inline position in line box
     fn assign_position(&self, line_breaker: &mut LineBreaker<'a>) {
         for line in &line_breaker.lines {
             let mut line_box_x = line.bounds.content.x;
@@ -352,6 +338,7 @@ impl<'a> InlineBox<'a> {
                     d.content.y += new_rect_y;
                 }
                 if let BoxType::InlineNode(_) = item.box_type {
+                    let line_box_x = { line_box_x + item.dimensions.borrow().margin_left_offset() };
                     self.recursive_position(item, line_box_x, new_rect_y);
                 }
                 let d = item.dimensions.borrow();

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -337,7 +337,7 @@ impl<'a> InlineBox<'a> {
                 }
                 if let BoxType::InlineNode(_) = item.box_type {
                     let line_box_x = { line_box_x + item.dimensions.borrow().margin_left_offset() };
-                    self.recursive_position(item, line_box_x, new_rect_y);
+                    self.calculate_child_position(item, line_box_x, new_rect_y);
                 }
                 let d = item.dimensions.borrow();
                 let margin_box = d.margin_horizontal_box();
@@ -350,7 +350,7 @@ impl<'a> InlineBox<'a> {
         }
     }
 
-    fn recursive_position(
+    fn calculate_child_position(
         &self,
         layout_box: &mut LayoutBox<'a>,
         additional_rect_x: f32,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -350,6 +350,27 @@ impl<'a> LayoutBox<'a> {
         d.padding.left = node.lookup("padding-left", "padding", &zero).to_px();
         d.padding.right = node.lookup("padding-right", "padding", &zero).to_px();
     }
+
+    fn reset_edge_left(&mut self) {
+        let mut d = self.dimensions.borrow_mut();
+        d.margin.left = 0.;
+        d.border.left = 0.;
+        d.padding.left = 0.;
+        if self.children.len() != 0 {
+            self.children[0].reset_edge_left();
+        }
+    }
+
+    fn reset_edge_right(&mut self) {
+        let mut d = self.dimensions.borrow_mut();
+        d.margin.right = 0.;
+        d.border.right = 0.;
+        d.padding.right = 0.;
+        let len = self.children.len();
+        if len != 0 {
+            self.children[len - 1].reset_edge_right();
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -353,6 +353,29 @@ impl<'a> LayoutBox<'a> {
         d.padding.left = node.lookup("padding-left", "padding", &zero).to_px();
         d.padding.right = node.lookup("padding-right", "padding", &zero).to_px();
     }
+
+    fn reset_edge_left(&mut self) {
+        self.is_splitted = true;
+        let mut d = self.dimensions.borrow_mut();
+        d.margin.left = 0.;
+        d.border.left = 0.;
+        d.padding.left = 0.;
+        if self.children.len() != 0 {
+            self.children[0].reset_edge_left();
+        }
+    }
+
+    fn reset_edge_right(&mut self) {
+        self.is_splitted = true;
+        let mut d = self.dimensions.borrow_mut();
+        d.margin.right = 0.;
+        d.border.right = 0.;
+        d.padding.right = 0.;
+        let len = self.children.len();
+        if len != 0 {
+            self.children[len - 1].reset_edge_right();
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -136,15 +136,15 @@ impl<'a> LayoutBox<'a> {
         match self.box_type {
             BoxType::BlockNode(_) => self.layout_block(containing_block),
             BoxType::AnonymousBlock => {
+                let containing_block = containing_block.borrow();
                 {
                     let mut d = self.dimensions.borrow_mut();
-                    let containing_block = containing_block.borrow();
                     d.content.x = containing_block.content.x;
                     d.content.y = containing_block.content.y;
                 }
                 // Anonymous block is including only inline box in children
                 let mut inline_box =
-                    InlineBox::new(self.clone(), mem::replace(&mut self.children, Vec::new()));
+                    InlineBox::new(containing_block.clone(), mem::replace(&mut self.children, Vec::new()));
                 inline_box.process();
                 let mut d = self.dimensions.borrow_mut();
                 d.content.width = inline_box.width;

--- a/src/painter/mod.rs
+++ b/src/painter/mod.rs
@@ -102,10 +102,7 @@ fn render_text(list: &mut DisplayList, layout_box: &LayoutBox) {
         _ => return,
     };
 
-    let text = match &(*node.styled_node.node).node_type {
-        NodeType::Text(text) => text,
-        _ => unreachable!(),
-    };
+    let text = node.get_text();
 
     let color = get_color(layout_box, "color").unwrap_or_else(|| Color::new(0, 0, 0, 1.0));
     list.push(DisplayCommand::Text(

--- a/src/painter/mod.rs
+++ b/src/painter/mod.rs
@@ -51,49 +51,57 @@ fn render_borders(list: &mut DisplayList, layout_box: &LayoutBox) {
     let d = layout_box.dimensions.borrow();
     let border_box = d.border_box();
 
-    // border-left
-    list.push(DisplayCommand::SolidColor(
-        color.clone(),
-        Rect {
-            x: border_box.x,
-            y: border_box.y,
-            width: d.border.left,
-            height: border_box.height,
-        },
-    ));
+    if d.border.left != 0. {
+        // border-left
+        list.push(DisplayCommand::SolidColor(
+            color.clone(),
+            Rect {
+                x: border_box.x,
+                y: border_box.y,
+                width: d.border.left,
+                height: border_box.height,
+            },
+        ));
+    }
 
-    // border-right
-    list.push(DisplayCommand::SolidColor(
-        color.clone(),
-        Rect {
-            x: border_box.x + border_box.width - d.border.right,
-            y: border_box.y,
-            width: d.border.right,
-            height: border_box.height,
-        },
-    ));
+    if d.border.right != 0. {
+        // border-right
+        list.push(DisplayCommand::SolidColor(
+            color.clone(),
+            Rect {
+                x: border_box.x + border_box.width - d.border.right,
+                y: border_box.y,
+                width: d.border.right,
+                height: border_box.height,
+            },
+        ));
+    }
 
-    // border-top
-    list.push(DisplayCommand::SolidColor(
-        color.clone(),
-        Rect {
-            x: border_box.x,
-            y: border_box.y,
-            width: border_box.width,
-            height: d.border.top,
-        },
-    ));
+    if d.border.top != 0. {
+        // border-top
+        list.push(DisplayCommand::SolidColor(
+            color.clone(),
+            Rect {
+                x: border_box.x,
+                y: border_box.y,
+                width: border_box.width,
+                height: d.border.top,
+            },
+        ));
+    }
 
-    // border-top
-    list.push(DisplayCommand::SolidColor(
-        color,
-        Rect {
-            x: border_box.x,
-            y: border_box.y + border_box.height - d.border.bottom,
-            width: border_box.width,
-            height: d.border.bottom,
-        },
-    ));
+    if d.border.bottom != 0. {
+        // border-bottom
+        list.push(DisplayCommand::SolidColor(
+            color,
+            Rect {
+                x: border_box.x,
+                y: border_box.y + border_box.height - d.border.bottom,
+                width: border_box.width,
+                height: d.border.bottom,
+            },
+        ));
+    }
 }
 
 fn render_text(list: &mut DisplayList, layout_box: &LayoutBox) {

--- a/status.md
+++ b/status.md
@@ -19,6 +19,10 @@
     - inline-start: left-top of containing block 
     - inline-end: text width
 - [x] style inheritance
-- [ ] line break
+- [x] line break
+  - [x] `line-break: auto;`
+  - [x] `word-break: normal;`
+  - [ ] `word-break: break-all;` ... for japanese
+  - [x] `overflow-wrap: normal;`
 - [ ] white space
 - [ ] vertical align, text-align


### PR DESCRIPTION
target: implement `overflow-wrap: break-word;`

1. Check advanced width for a character one by one
2. Calculate remaining width based on advanced width
3. If advanced width is larger than remaining width, this point is break point(called inline_start). But、if box has structure like `foo<span>bar</span>`, it is not broken between foo and  bar.
4. save distance between overflow position and end position(inline_end)
5. store range of inline_start and inline_end to TextNode.range, and create new TextNode
6. if inline_start and inline_end is exist、make margin-right, border-right and padding-right to be 0 in inline_start, and make margin-left, border-left and padding-left to be 0 in inline_end
7. store inline_start to LineBreaker::lines, and store inline_end to work_list